### PR TITLE
chore: package files

### DIFF
--- a/packages/react-rtc/package.json
+++ b/packages/react-rtc/package.json
@@ -9,6 +9,9 @@
   "author": "torolocos",
   "main": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
GH card ticket "link": #ADD LINK TO GITHUB TICKET OR ISSUE

### Description
Addinf `files` to package.json we restirct which files should be in package. This will reduce package size, also we will ship only necessary files.
```
petr.chalupa:~/Documents/react-rtc/packages/react-rtc main $ npm publish --dry-run
npm notice 
npm notice 📦  @torolocos/react-rtc@0.1.5
npm notice === Tarball Contents === 
npm notice 1.2kB  package.json          
npm notice 23.6kB dist/esm/index.mjs.map
npm notice 9.3kB  dist/esm/index.mjs    
npm notice 2.4kB  dist/types/index.d.ts 
npm notice === Tarball Details === 
npm notice name:          @torolocos/react-rtc                    
npm notice version:       0.1.5                                   
npm notice package size:  7.9 kB                                  
npm notice unpacked size: 36.5 kB                                 
npm notice shasum:        c357580b0d3eabf4511034674861a2bc67b3e1aa
npm notice integrity:     sha512-6gkDVKP7eoRfY[...]9ppDX7UWztAKA==
npm notice total files:   4                                       
npm notice 
+ @torolocos/react-rtc@0.1.5
```