### PR TITLE
chore: update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-GH card ticket "link": #ADD LINK TO GITHUB TICKET OR ISSUE
-
 ### Description
 
 (FILL IN SOME DESCRIPTION)


### PR DESCRIPTION
GH card ticket "link": #ADD LINK TO GITHUB TICKET OR ISSUE

### Description

In most of the PRs we don't use the line for "GH card ticket". I think It is safe to remove it from a template. There is a better way how to link issues in PR, see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
