### PR TITLE
chore: filter out web-example build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --filter=!web-example",
     "dev": "turbo run dev",
     "lint": "turbo run lint --parallel",
     "tsc:check": "turbo run lint --parallel",


### PR DESCRIPTION
### Description

We don't need to build a `web-example`, because this app is not finished yet.
